### PR TITLE
Adding dockerfile for jruby-9.1.12.0

### DIFF
--- a/9.1.12.0/Dockerfile
+++ b/9.1.12.0/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -SL https://github.com/postmodern/ruby-install/archive/master.tar.gz | 
     cd /tmp/ruby-install-master && make install && \
     cd .. && rm -rf ruby-install-master
 
-RUN apt-get update && apt-get install -y ruby && apt-get install -y openjdk-7-jdk && \
+RUN apt-get update && apt-get install -y ruby && apt-get install -y openjdk-8-jdk && \
     ruby-install \
     # -p https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/${JRUBY_VERSION}/railsexpress/01-skip-broken-tests.patch \
     # -p https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/${JRUBY_VERSION}/railsexpress/02-improve-gc-stats.patch \

--- a/jruby-9.1.12.0/Dockerfile
+++ b/jruby-9.1.12.0/Dockerfile
@@ -1,0 +1,59 @@
+FROM phusion/baseimage:0.9.19
+MAINTAINER CloudFactory <devops@cloudfactory.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV JRUBY_VERSION 9.1.12.0
+ENV BUNDLER_VERSION 1.14.4
+
+RUN add-apt-repository ppa:openjdk-r/ppa && apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
+    apt-get install -y curl ca-certificates git build-essential libtool autoconf deborphan && \
+    apt-get -y clean && apt-get -y autoclean && apt-get -y autoremove && \
+    deborphan | xargs apt-get remove --purge -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -SL https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz | tar -xzvC /tmp && \
+    cd /tmp/chruby-0.3.9 && make install && \
+    cd .. && rm -rf chruby-0.3.9
+
+RUN curl -SL https://github.com/postmodern/ruby-install/archive/master.tar.gz | tar -xzvC /tmp && \
+    cd /tmp/ruby-install-master && make install && \
+    cd .. && rm -rf ruby-install-master
+
+RUN apt-get update && apt-get install -y ruby && apt-get install -y openjdk-7-jdk && \
+    ruby-install \
+    # -p https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/${JRUBY_VERSION}/railsexpress/01-skip-broken-tests.patch \
+    # -p https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/${JRUBY_VERSION}/railsexpress/02-improve-gc-stats.patch \
+    # -p https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/${JRUBY_VERSION}/railsexpress/03-display-more-detailed-stack-trace.patch \
+    jruby ${JRUBY_VERSION} -- --disable-install-rdoc --enable-shared CFLAGS="-O3" && \
+    rm -rf /usr/local/src && \
+    apt-get remove --purge -y ruby && \
+    apt-get -y autoremove && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+RUN echo '[ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ] || return' >> /etc/profile.d/chruby.sh && \
+    echo 'source /usr/local/share/chruby/chruby.sh' >> /etc/profile.d/chruby.sh && \
+    echo 'chruby ruby' >> /etc/profile.d/default_ruby.sh && \
+    chruby-exec ruby -- gem install bundler --version "$BUNDLER_VERSION"
+
+# install things sort of globally so that we could use shared space
+# as poor man's way of gem caching maybe
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+        BUNDLE_BIN="$GEM_HOME/bin" \
+        BUNDLE_SILENCE_ROOT_WARNING=1 \
+        BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH /opt/rubies/jruby-${JRUBY_VERSION}/bin:$BUNDLE_BIN:$PATH
+
+
+#Making bundle fast
+RUN  mkdir -p "$GEM_HOME" "$BUNDLE_BIN"&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN" && \
+    { \
+                echo 'install: --no-document'; \
+                echo 'update: --no-document'; \
+          } > ~/.gemrc && \
+    { \
+      echo '---'; \
+      echo 'BUNDLE_JOBS: '3''; \
+    } > $BUNDLE_APP_CONFIG/config


### PR DESCRIPTION
### Motivation
Since **pulseviz** is using **jruby-9.1.12.0**, creating dockerfile for this version of ruby.

### Changes:
1. Added **ppa** for **openjdk-7-jdk**
2. Installed **openjdk7-jdk**
3. Installed **jruby-9.1.12.0**

**Note**: Not sure if this is the repo to place dockerfile for jruby-9.1.12.0 though.
cc: @cloudfactory/devops 